### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -80,9 +80,14 @@ def create_app(config_name='development'):
     def serve_react(path):
         if path.startswith('api') or path.startswith('auth'):
             return "Not Found", 404
-        if path != "" and os.path.exists(os.path.join(app.static_folder, path)):
-            return send_from_directory(app.static_folder, path)
-        else:
-            return send_from_directory(app.static_folder, 'index.html')
+        if path != "":
+            # Normalize the user-supplied path and ensure it's within static folder
+            abs_static_folder = os.path.abspath(app.static_folder)
+            normalized_path = os.path.normpath(os.path.join(abs_static_folder, path))
+            if normalized_path.startswith(abs_static_folder) and os.path.exists(normalized_path):
+                # Serve only if the normalized path is inside the static folder
+                rel_path = os.path.relpath(normalized_path, abs_static_folder)
+                return send_from_directory(abs_static_folder, rel_path)
+        return send_from_directory(app.static_folder, 'index.html')
 
     return app


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/EVXchange/security/code-scanning/4](https://github.com/ajharris/EVXchange/security/code-scanning/4)

To fix the vulnerability, we need to ensure that the file path constructed from the user-provided `path` is constrained to only access files within the intended static root (`app.static_folder`). This should:
- Normalize the constructed path using `os.path.normpath`.
- Ensure the normalized path starts with (is inside) the static root directory, using an absolute path comparison.
- Only serve the file if it's within the allowed directory; otherwise, return an error or fallback to `index.html`.

Implementation:
- In the `serve_react` function (lines 80–86), before using `os.path.join(app.static_folder, path)`, normalize and check the path as per best practice (see background and provided examples).
- No additional methods or complex logic imports are needed; use the standard library `os.path` methods available.
- All changes are limited to the serve_react function in backend/app/__init__.py.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
