### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -5,7 +5,7 @@ from flask import url_for, session
 from flask_login import current_user
 from models.user import User
 from backend.app import db
-
+from urllib.parse import urlparse
 class TestAuthRoutes:
     """Test cases for authentication routes"""
     
@@ -24,7 +24,7 @@ class TestAuthRoutes:
             response = client.get('/auth/login/facebook')
             
             assert response.status_code == 302
-            assert 'facebook.com' in response.location
+            assert urlparse(response.location).hostname == "facebook.com"
             assert 'client_id=test-facebook-app-id' in response.location
     
     def test_oauth_login_linkedin(self, client, app):


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/EVXchange/security/code-scanning/2](https://github.com/ajharris/EVXchange/security/code-scanning/2)

**General Fix:**  
Rather than checking if `"facebook.com"` is a substring of the URL, parse the target URL and assert that the `hostname` is either exactly `"facebook.com"` or a valid subdomain (if intended). This avoids passing tests when `"facebook.com"` appears somewhere other than as the redirect target host.

**Detailed Fix:**  
- In file `backend/tests/test_auth_routes.py`, within the `test_oauth_login_facebook` method, replace `assert 'facebook.com' in response.location` with parsing the response location using `urllib.parse.urlparse` and then checking the `hostname` field.
- This requires importing `urlparse` from `urllib.parse` at the top of the file.
- Make these checks stricter and consistent for other test cases if desired, but only fix the flagged line now.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
