### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -2,6 +2,7 @@ import pytest
 import responses
 from unittest.mock import patch, MagicMock
 from flask import url_for, session
+from urllib.parse import urlparse
 from flask_login import current_user
 from models.user import User
 from backend.app import db
@@ -15,7 +16,7 @@ class TestAuthRoutes:
             response = client.get('/auth/login/google')
             
             assert response.status_code == 302
-            assert 'accounts.google.com' in response.location
+            assert urlparse(response.location).hostname == "accounts.google.com"
             assert 'client_id=test-google-client-id' in response.location
     
     def test_oauth_login_facebook(self, client, app):


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/EVXchange/security/code-scanning/1](https://github.com/ajharris/EVXchange/security/code-scanning/1)

To fix the issue, edit the assertion by parsing `response.location` as a URL, extracting its hostname, and comparing it to the expected host string. To do this in Python, use the standard library's `urllib.parse.urlparse`. Update the assertion so it reads something like `assert urlparse(response.location).hostname == "accounts.google.com"`. This should be done in the affected test function (in this case, `test_oauth_login_google`). You'll need to import `urlparse` from `urllib.parse` at the top of the file. Change only the assertion in this test function and add the new import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
