### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/backend/routes/api.py
+++ b/backend/routes/api.py
@@ -2,9 +2,11 @@ import os
 import stripe
 from flask import Blueprint, jsonify, request, g
 from flask_login import login_required, current_user
-
+import logging
 api_bp = Blueprint('api', __name__)
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 # --- User Dashboard Endpoint (Mock) ---
 @api_bp.route('/dashboard')
 @login_required
@@ -230,7 +232,8 @@ def stripe_webhook():
             payload, sig_header, endpoint_secret
         )
     except Exception as e:
-        return jsonify({"error": str(e)}), 400
+        logger.exception("Error while processing Stripe webhook event.")
+        return jsonify({"error": "Invalid payload or signature"}), 400
     # Handle event type
     if event["type"] == "checkout.session.completed":
         # Here you would update booking/payment status


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/EVXchange/security/code-scanning/7](https://github.com/ajharris/EVXchange/security/code-scanning/7)

To fix the information exposure issue, the code should return a generic error message in response to exceptions, rather than including the details of the exception itself. Internally, the application should log the exception (including the stack trace, if useful) for later debugging, but not expose this level of detail to users. The changes should be applied to the Stripe webhook endpoint (lines 228–233), replacing the exposure of `str(e)` with a safe, non-detailed message. In order to log the error on the server, Python's standard `logging` library will be used if not already present, and the exception will be logged with `logger.exception()` to capture the full traceback. This requires importing and configuring the logging module if not already done.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
