### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -5,6 +5,7 @@ from flask import url_for, session
 from flask_login import current_user
 from models.user import User
 from backend.app import db
+from urllib.parse import urlparse
 
 class TestAuthRoutes:
     """Test cases for authentication routes"""
@@ -33,7 +34,7 @@ class TestAuthRoutes:
             response = client.get('/auth/login/linkedin')
             
             assert response.status_code == 302
-            assert 'linkedin.com' in response.location
+            assert urlparse(response.location).hostname == "linkedin.com"
             assert 'client_id=test-linkedin-client-id' in response.location
     
     def test_oauth_login_invalid_provider(self, client):


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/EVXchange/security/code-scanning/3](https://github.com/ajharris/EVXchange/security/code-scanning/3)

To avoid incomplete substring checks, even in tests, parse the URL and assert that the host of the redirect location matches `linkedin.com` or (better) matches an allowlist of LinkedIn domains, taking subdomains into account if needed.

Change the assertion in the test for LinkedIn (`assert 'linkedin.com' in response.location`) to instead parse `response.location` as a URL, extract the host part, and check that the host is exactly `linkedin.com` (or fits the desired allowlist pattern). This can be achieved with Python's `urllib.parse.urlparse`. Add the necessary import if not present.

Edit the assertion on line 36 as follows:
- Replace `assert 'linkedin.com' in response.location`
- With: parse `response.location`, extract the host, and check it matches the expected host.

If `urllib.parse` is not already imported in this file, import it at the top.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
