### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/backend/routes/api.py
+++ b/backend/routes/api.py
@@ -220,7 +220,8 @@ def create_checkout_session():
         )
         return jsonify({"checkout_url": session.url})
     except Exception as e:
-        return jsonify({"error": str(e)}), 400
+        logger.exception("Error creating Stripe checkout session.")
+        return jsonify({"error": "Failed to create checkout session."}), 400
 
 @api_bp.route('/payments/webhook', methods=['POST'])
 def stripe_webhook():


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/EVXchange/security/code-scanning/6](https://github.com/ajharris/EVXchange/security/code-scanning/6)

**How to fix, in general:**  
To avoid leaking sensitive error messages, the server should always log the exception with stack trace on the server side for debugging, but return only a generic error message to the client. The exception string should never be sent directly to the client.

**Best way to fix for this file/region:**  
Within the `except Exception as e` block in the `create_checkout_session()` endpoint, replace the `return jsonify({"error": str(e)})` with two actions:
1. Log the exception using `logger.exception(...)`, which writes out the stack trace to server logs.
2. Return a sanitized, generic message (e.g., `jsonify({"error": "Failed to create checkout session."})`), ensuring clients do not see sensitive internal details.

**Changes needed:**
- The change is localized to lines 222-223 in `backend/routes/api.py`.
- No new imports required since `logger` is already declared/configured.
- No changes to method signatures or behavior, except more secure error handling.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
