### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -25,7 +25,7 @@ class TestAuthRoutes:
             response = client.get('/auth/login/facebook')
             
             assert response.status_code == 302
-            assert 'facebook.com' in response.location
+            assert urlparse(response.location).hostname == "facebook.com"
             assert 'client_id=test-facebook-app-id' in response.location
     
     def test_oauth_login_linkedin(self, client, app):


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/EVXchange/security/code-scanning/2](https://github.com/ajharris/EVXchange/security/code-scanning/2)

Tests that check for the presence of `'facebook.com'` in the redirect location (and similar substring-based checks) should be replaced with robust checks that ensure the actual hostname in the redirect URL is exactly what is expected. This should be done using `urlparse` to parse `response.location` and then assert that the `hostname` attribute matches the expected value (e.g., `"facebook.com"`). Specifically, in `test_oauth_login_facebook`, replace `assert 'facebook.com' in response.location` with `assert urlparse(response.location).hostname == "facebook.com"`. Imports for `urlparse` can be kept as they are (already present). No changes should be made to test logic apart from the assertion update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
