### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/backend/tests/test_auth_routes.py
+++ b/backend/tests/test_auth_routes.py
@@ -16,7 +16,7 @@ class TestAuthRoutes:
             response = client.get('/auth/login/google')
             
             assert response.status_code == 302
-            assert 'accounts.google.com' in response.location
+            assert urlparse(response.location).hostname == "accounts.google.com"
             assert 'client_id=test-google-client-id' in response.location
     
     def test_oauth_login_facebook(self, client, app):


### PR DESCRIPTION
Potential fix for [https://github.com/ajharris/EVXchange/security/code-scanning/1](https://github.com/ajharris/EVXchange/security/code-scanning/1)

To fix the problem, replace the substring check (`'accounts.google.com' in response.location`) with a check on the parsed hostname of the URL, using `urlparse(response.location).hostname == "accounts.google.com"`. This ensures the test passes only if the redirect is actually to Google's OAuth host, rather than anywhere that merely contains the substring. The rest of the test functionality (ensuring the client ID is present) remains unchanged. Only line 19 must be changed, as `urlparse` is already imported in the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
